### PR TITLE
Improve the 'API documentation' link

### DIFF
--- a/bin/magi-release-notes
+++ b/bin/magi-release-notes
@@ -38,7 +38,7 @@ async function main(fromVersion, toVersion) {
 
   console.log(`\
 [Live Demo →](https://cdn.vaadin.com/${packageName}/${toVersionNumber}/demo/)
-[API Documentation →](https://cdn.vaadin.com/${packageName}/${toVersionNumber}/)
+[API Documentation →](https://cdn.vaadin.com/${packageName}/${toVersionNumber}/#/elements/${packageName})
 
 ### Changes Since [${fromVersion}](https://github.com/vaadin/${packageName}/releases/tag/${fromVersion}):
 


### PR DESCRIPTION
Instead of showing the blank page, let's show the API documentation :)

Before: https://cdn.vaadin.com/vaadin-progress-bar/1.0.0-alpha1/
After: https://cdn.vaadin.com/vaadin-progress-bar/1.0.0-alpha1/#/elements/vaadin-progress-bar